### PR TITLE
Add burger menu

### DIFF
--- a/components/burger-menu.js
+++ b/components/burger-menu.js
@@ -16,7 +16,7 @@ customElements.define('antidote-burger-menu', component(function AdvisorContext(
     </ul>
     
     <div class="burger" @click=${toggleBurger}>
-      <div class="line"></div>a
+      <div class="line"></div>
       <div class="line"></div>
       <div class="line"></div>
     </div>    

--- a/components/burger-menu.js
+++ b/components/burger-menu.js
@@ -1,0 +1,24 @@
+import { html } from 'lit-html';
+import { component } from 'haunted';
+import getComponentStyleSheetURL from '../helpers/stylesheet';
+
+function toggleBurger() {
+  this.classList.toggle('cross');
+  this.parentElement.querySelector('.burger-nav').classList.toggle('active');
+  document.body.classList.toggle('overflow-hidden');
+}
+
+customElements.define('antidote-burger-menu', component(function AdvisorContext() {
+  return html`
+    <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
+    <ul class="burger-nav">
+      <slot></slot>
+    </ul>
+    
+    <div class="burger" @click=${toggleBurger}>
+      <div class="line"></div>
+      <div class="line"></div>
+      <div class="line"></div>
+    </div>    
+  `
+}));

--- a/components/burger-menu.js
+++ b/components/burger-menu.js
@@ -4,7 +4,7 @@ import getComponentStyleSheetURL from '../helpers/stylesheet';
 
 function toggleBurger() {
   this.classList.toggle('cross');
-  this.parentElement.querySelector('.burger-nav').classList.toggle('active');
+  this.parentNode.querySelector('.burger-nav').classList.toggle('active');
   document.body.classList.toggle('overflow-hidden');
 }
 
@@ -16,7 +16,7 @@ customElements.define('antidote-burger-menu', component(function AdvisorContext(
     </ul>
     
     <div class="burger" @click=${toggleBurger}>
-      <div class="line"></div>
+      <div class="line"></div>a
       <div class="line"></div>
       <div class="line"></div>
     </div>    

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ export * from "./components/select.js";
 export * from "./components/progress-bar.js";
 export * from "./components/advisor.js";
 export * from "./components/advisor-context.js";
+export * from "./components/burger-menu.js";
 export * from "./components/terminal.js";
 export * from './components/lab-context.js';
 export * from "./components/lab-stage-selector.js";


### PR DESCRIPTION
Added encapsulation of the burger menu for use in antidote pages. This uses more a componentized approach than the menu toggle logic used in the Hugo theme. Both Hugo and this component use the same styles.