### PR TITLE
Throw exception on failure status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixes to issues discovered during deploy process [#3](https://github.com/nre-learning/antidote-ui-components/pull/3)
 - Add class to collection logo, fix l8n strings [#10](https://github.com/nre-learning/antidote-ui-components/pull/10)
-
+- Throw exception on failure status codes from Syringe [#11](https://github.com/nre-learning/antidote-ui-components/pull/11)
 ## v0.4.0 - N/A
 
 This release of Antidote took place before this repository was created.

--- a/components/lab-loading-modal.js
+++ b/components/lab-loading-modal.js
@@ -17,13 +17,13 @@ function LabLoadingModal() {
     if (lessonRequest.error) {
       console.error(lessonRequest.error);
       return html`
-      <h3>${l8n('lab.loading.modal.lesson.loading.error.message', { lesson: lessonRequest.error })}</h3>
+      <h3>${l8n('lab.loading.modal.lesson.loading.error.message', { error: lessonRequest.error })}</h3>
     `;
     }
     else if (detailRequest.error) {
       console.error(detailRequest.error);
       return html`
-      <h3>${l8n('lab.loading.modal.lesson.detail.loading.error.message', { lesson: detailRequest.error })}</h3>
+      <h3>${l8n('lab.loading.modal.lesson.detail.loading.error.message', { error: detailRequest.error })}</h3>
     `;
     }
     else if (!lessonRequest.completed) {

--- a/helpers/use-fetch.js
+++ b/helpers/use-fetch.js
@@ -26,8 +26,13 @@ export default function useFetch(path, options) {
 
       try {
         const response = await fetch(url, options);
+        const data = options && options.text ? await response.text() : await response.json();
+        // fetch() doesn't throw exceptions for HTTP error codes so we need to do this ourselves.
+        if (response.status >= 400) {
+            throw new Error(typeof data == "object" && data.error ? data.error : data);
+        }
         setRequestState({
-          data: options && options.text ? await response.text() : await response.json(),
+          data: data,
           pending: false,
           completed: true,
           succeeded: true,

--- a/helpers/use-polling-request.js
+++ b/helpers/use-polling-request.js
@@ -63,7 +63,10 @@ export default function usePollingRequest({
         try {
           const response = await fetch(`${progressRequestURL}`);
           const data = await response.json();
-
+          // fetch() doesn't throw exceptions for HTTP error codes so we need to do this ourselves.
+          if (response.status >= 400) {
+              throw new Error(typeof data == "object" && data.error ? data.error : data);
+          }
           if (isProgressComplete(data)) {
             setProgressRequestState({
               data,


### PR DESCRIPTION
In #4, it was discovered that a variety of errors weren't being handled properly. Not only were these errors not being bubbled up to the user in the progress modal, it seemed like they weren't even impacting application flow - an error response in the initial livelesson request, for instance, wouldn't prevent the rest of the front-end code from executing, and trying to get a livelesson by an `undefined` UUID.

Turns out that the javascript `fetch()` function, used by both `use-fetch.js` and `use-polling-request.js`, doesn't actually throw an exception for responses with error codes. So, the existing exception handling never triggers. I'm not sure if I ever knew this, but I do now :smile:

This PR adds logic to throw an exception when a status code of 400 or above is detected, in both of these functions. It also fixes a bug where the wrong variable was being sent to the error message l8n strings. Combined, these changes allow errors to not only properly halt the workflow of retrieving a lesson from the back-end, it also provides the right message to the user.

Closes #4 