### PR TITLE
Moving to DNS-based location for http presentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fixes to issues discovered during deploy process [#3](https://github.com/nre-learning/antidote-ui-components/pull/3)
 - Add class to collection logo, fix l8n strings [#10](https://github.com/nre-learning/antidote-ui-components/pull/10)
 - Throw exception on failure status codes from Syringe [#11](https://github.com/nre-learning/antidote-ui-components/pull/11)
+- Moving to DNS-based location for http presentations [#12](https://github.com/nre-learning/antidote-ui-components/pull/12)
+
 ## v0.4.0 - N/A
 
 This release of Antidote took place before this repository was created.

--- a/components/lab-guide.js
+++ b/components/lab-guide.js
@@ -72,7 +72,7 @@ function LabGuide() {
   if (lessonDetailsRequest.succeeded) {
     if (lessonDetailsRequest.data.JupyterLabGuide) {
       const path = `/notebooks/stage${lessonStage}/notebook.ipynb`;
-      const url = `${serviceHost}/${lessonId}-${sessionId}-ns-jupyterlabguide${path}`;
+      const url = `${window.location.protocol}//${lessonId}-${sessionId}-ns-jupyterlabguide-web.heps.${window.location.host}${path}`
 
       guideContent = html`
         <iframe src="${url}"></iframe>

--- a/components/lab-guide.js
+++ b/components/lab-guide.js
@@ -26,6 +26,11 @@ document.runSnippetInTab = function runSnippetInTab(id, snippetIndex) {
   terminalEl.run(text);
 };
 
+// Helper function for the lesson author to quickly switch to another tab, but not run any commands
+document.switchToTab = function switchToTab(id) {
+  document.querySelector('antidote-lab-tab-switcher').setSelectedPresentation(id)
+};
+
 // attach scroll listener to send scroll position events, allowing position synchronization with
 // any other guides on the page for this lesson (e.g one that will be shown in when in mobile layout)
 function useSyncronizedScrolling(guide) {

--- a/components/lab-tabs.js
+++ b/components/lab-tabs.js
@@ -34,9 +34,6 @@ function getTabMarkup(tab) {
           </div>
         `;
       case('http'):
-        console.log("MIERDIN1")
-        console.log(tab)
-        console.log(tab.id)
         return html`
           <div id=${tab.id}
                tab="web" 

--- a/components/lab-tabs.js
+++ b/components/lab-tabs.js
@@ -34,11 +34,14 @@ function getTabMarkup(tab) {
           </div>
         `;
       case('http'):
+        console.log("MIERDIN1")
+        console.log(tab)
+        console.log(tab.id)
         return html`
           <div id=${tab.id}
                tab="web" 
                ?selected=${tab.selected}>
-            <iframe src="${serviceHost}/${lessonId}-${sessionId}-ns-${tab.pres.endpoint}/">
+            <iframe src="${lessonId}-${sessionId}-ns-${tab.pres.endpoint}-explorer.heps.${serviceHost}/">
             </iframe>
           </div>
         `;

--- a/components/lab-tabs.js
+++ b/components/lab-tabs.js
@@ -41,7 +41,7 @@ function getTabMarkup(tab) {
           <div id=${tab.id}
                tab="web" 
                ?selected=${tab.selected}>
-            <iframe src="${window.location.protocol}//${lessonId}-${sessionId}-ns-${tab.pres.endpoint}-explorer.heps.${window.location.host}/">
+            <iframe src="${window.location.protocol}//${lessonId}-${sessionId}-ns-${tab.pres.id}.heps.${window.location.host}/">
             </iframe>
           </div>
         `;

--- a/components/lab-tabs.js
+++ b/components/lab-tabs.js
@@ -41,7 +41,7 @@ function getTabMarkup(tab) {
           <div id=${tab.id}
                tab="web" 
                ?selected=${tab.selected}>
-            <iframe src="${window.location.protocol}//${lessonId}-${sessionId}-ns-${tab.pres.id}.heps.${window.location.host}/">
+            <iframe src="${window.location.protocol}//${lessonId}-${sessionId}-ns-${tab.id}.heps.${window.location.host}/">
             </iframe>
           </div>
         `;

--- a/components/lab-tabs.js
+++ b/components/lab-tabs.js
@@ -41,7 +41,7 @@ function getTabMarkup(tab) {
           <div id=${tab.id}
                tab="web" 
                ?selected=${tab.selected}>
-            <iframe src="${lessonId}-${sessionId}-ns-${tab.pres.endpoint}-explorer.heps.${serviceHost}/">
+            <iframe src="${window.location.protocol}//${lessonId}-${sessionId}-ns-${tab.pres.endpoint}-explorer.heps.${window.location.host}/">
             </iframe>
           </div>
         `;


### PR DESCRIPTION
This PR implements the front-end changes needed to adhere to the new model for provisioning HTTP presentations in https://github.com/nre-learning/syringe/pull/151.

This applies to both HTTP presentations for lesson endpoints, as well as jupyter notebooks. We are no longer appending unique identifiers as a path element, but rather as part of the subdomain.