### PR TITLE
Standardize lesson guide header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Antidote-Core Compatibility Updates [#15](https://github.com/nre-learning/antidote-ui-components/pull/15)
+- Standardize Lesson Guide Header [#17](https://github.com/nre-learning/antidote-ui-components/pull/17)
 
 ## v0.5.1 - February 17, 2020
 

--- a/components/lab-guide.js
+++ b/components/lab-guide.js
@@ -80,7 +80,7 @@ function LabGuide() {
 
   if (lessonDetailsRequest.succeeded) {
     if (lessonDetailsRequest.data.GuideType == 'jupyter') {
-      const path = `/notebooks/stage${lessonStage}/notebook.ipynb`;
+      const path = `/notebooks/stage${lessonStage}/guide.ipynb`;
       const url = `${window.location.protocol}//${lessonDetailsRequest.data.AntidoteID}-${lessonDetailsRequest.data.ID}-jupyterlabguide-web.heps.${window.location.host}${path}`
 
       guideContent = html`
@@ -100,15 +100,15 @@ function LabGuide() {
   useSyncronizedScrolling.apply(this);
   return lessonRequest.completed && lessonDetailsRequest.completed ? html`
     <div>
-      <h2>${lessonRequest.data.Name}</h2>
-      <h3 style="margin-top: 0px;">Chapter ${lessonStage+1} - ${lessonRequest.data.Stages[lessonStage].Description}</h3>
+      <h1>${lessonRequest.data.Name}</h1>
+      <h2 style="margin-top: 0px;">Chapter ${lessonStage+1} - ${lessonRequest.data.Stages[lessonStage].Description}</h2>
       ${lessonRequest.data.Authors && lessonRequest.data.Authors.length > 0 ? html`<p>
         ${lessonRequest.data.Authors.length > 1 ? l8n('lab.author.plural.label') : l8n('lab.author.singular.label')}: ${lessonRequest.data.Authors.map((author, i) => html`<a target="_blank" href="${author.Link}">${author.Name}</a>${(i>=lessonRequest.data.Authors.length-1) ? '' : ', '}`)}
       </p>`: ''}
-      <hr />
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
-    ${guideContent}
+    ${lessonDetailsRequest.data.GuideType == 'markdown' ? guideContent : ''}
     </div>
+    ${lessonDetailsRequest.data.GuideType == 'jupyter' ? guideContent : ''}
   ` : '';
 }
 


### PR DESCRIPTION
This adds a standard header that appears directly above a lesson guide, which includes the name of the lesson, the stage/chapter of the lesson, and any authors for the lesson. This allows the top-level identifiers for content to be much more consistent, and that much less content for the lesson author to write (no need to add duplicate information into the body of a lesson guide.

Due to the way that jupyter notebooks are implemented on the page as lesson guides, this header is only made available for markdown-sourced lesson guides. We may revisit this at a later date.

Closes https://github.com/nre-learning/antidote-ui-components/issues/16