### PR TITLE
Add button to edit on github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Antidote-Core Compatibility Updates [#15](https://github.com/nre-learning/antidote-ui-components/pull/15)
 - Standardize Lesson Guide Header [#17](https://github.com/nre-learning/antidote-ui-components/pull/17)
+- Add "Edit on Github" button [#19](https://github.com/nre-learning/antidote-ui-components/pull/19)
 
 ## v0.5.1 - February 17, 2020
 

--- a/components/lab-context.js
+++ b/components/lab-context.js
@@ -36,6 +36,7 @@ function derivePresentationsFromLessonDetails(detailsRequest) {
 customElements.define('antidote-lab-context', component(function AntidoteLabContext() {
   const l8n = getL8nReader(this);
   const lessonRequest = useFetch(`${syringeServiceRoot}/exp/lesson/${lessonSlug}`);
+  const curriculumRequest = useFetch(`${syringeServiceRoot}/exp/curriculum`);
   const liveLessonDetailRequest = usePollingRequest({
     initialRequestURL: `${syringeServiceRoot}/exp/livelesson`,
     initialRequestOptions: {
@@ -70,9 +71,11 @@ customElements.define('antidote-lab-context', component(function AntidoteLabCont
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
     <antidote-lesson-context-provider .value=${lessonRequest}>
     <antidote-live-lesson-details-context-provider .value=${liveLessonDetailRequest}>
+    <antidote-curriculum-context-provider .value=${curriculumRequest}>
     <antidote-lab-tabs-context-provider .value=${tabs}>
         <slot></slot>
     </antidote-lab-tabs-context-provider>      
+    </antidote-curriculum-context-provider>
     </antidote-live-lesson-details-context-provider>      
     </antidote-lesson-context-provider>
   `

--- a/components/lab-guide.js
+++ b/components/lab-guide.js
@@ -105,8 +105,8 @@ function LabGuide() {
       <h2 style="margin-top: 0px;">Chapter ${lessonStage+1} - ${lessonRequest.data.Stages[lessonStage].Description}</h2>
       ${lessonRequest.data.Authors && lessonRequest.data.Authors.length > 0 ? html`<p>
         ${lessonRequest.data.Authors.length > 1 ? l8n('lab.author.plural.label') : l8n('lab.author.singular.label')}: ${lessonRequest.data.Authors.map((author, i) => html`<a target="_blank" href="${author.Link}">${author.Name}</a>${(i>=lessonRequest.data.Authors.length-1) ? '' : ', '}`)}
-      <a id="github" class="btn primary github" href="${curriculumRequest.data.GitRoot}">Edit on Github</a>
       </p>`: ''}
+      <a id="github" target="_blank" class="btn primary github" href="${curriculumRequest.data.GitRoot}">Edit on Github</a>
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
     ${lessonDetailsRequest.data.GuideType == 'markdown' ? guideContent : ''}
     </div>

--- a/components/lab-guide.js
+++ b/components/lab-guide.js
@@ -103,10 +103,10 @@ function LabGuide() {
     <div>
       <h1>${lessonRequest.data.Name}</h1>
       <h2 style="margin-top: 0px;">Chapter ${lessonStage+1} - ${lessonRequest.data.Stages[lessonStage].Description}</h2>
-      ${lessonRequest.data.Authors && lessonRequest.data.Authors.length > 0 ? html`<p>
+      ${lessonRequest.data.Authors && lessonRequest.data.Authors.length > 0 ? html`<p style="margin-top: 0px;">
         ${lessonRequest.data.Authors.length > 1 ? l8n('lab.author.plural.label') : l8n('lab.author.singular.label')}: ${lessonRequest.data.Authors.map((author, i) => html`<a target="_blank" href="${author.Link}">${author.Name}</a>${(i>=lessonRequest.data.Authors.length-1) ? '' : ', '}`)}
       </p>`: ''}
-      <a id="github" target="_blank" class="btn primary github" href="${curriculumRequest.data.GitRoot}">Edit on Github</a>
+      <a id="github" target="_blank" class="btn primary github" href="${curriculumRequest.data.GitRoot}">Edit Lesson on Github</a>
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
     ${lessonDetailsRequest.data.GuideType == 'markdown' ? guideContent : ''}
     </div>

--- a/components/lab-guide.js
+++ b/components/lab-guide.js
@@ -1,7 +1,7 @@
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { useContext, useEffect, component } from 'haunted';
-import { LiveLessonDetailsContext, LessonContext } from '../contexts.js';
+import { LiveLessonDetailsContext, LessonContext, CurriculumContext } from '../contexts.js';
 
 import { serviceHost, lessonSlug, lessonStage } from "../helpers/page-state.js";
 import showdown from 'showdown';
@@ -75,6 +75,7 @@ function useSyncronizedScrolling(guide) {
 function LabGuide() {
   const l8n = getL8nReader(this);
   const lessonRequest = useContext(LessonContext);
+  const curriculumRequest = useContext(CurriculumContext);
   const lessonDetailsRequest = useContext(LiveLessonDetailsContext);
   let guideContent = "";
 
@@ -98,12 +99,13 @@ function LabGuide() {
   }
 
   useSyncronizedScrolling.apply(this);
-  return lessonRequest.completed && lessonDetailsRequest.completed ? html`
+  return curriculumRequest.completed && lessonRequest.completed && lessonDetailsRequest.completed ? html`
     <div>
       <h1>${lessonRequest.data.Name}</h1>
       <h2 style="margin-top: 0px;">Chapter ${lessonStage+1} - ${lessonRequest.data.Stages[lessonStage].Description}</h2>
       ${lessonRequest.data.Authors && lessonRequest.data.Authors.length > 0 ? html`<p>
         ${lessonRequest.data.Authors.length > 1 ? l8n('lab.author.plural.label') : l8n('lab.author.singular.label')}: ${lessonRequest.data.Authors.map((author, i) => html`<a target="_blank" href="${author.Link}">${author.Name}</a>${(i>=lessonRequest.data.Authors.length-1) ? '' : ', '}`)}
+      <a id="github" class="btn primary github" href="${curriculumRequest.data.GitRoot}">Edit on Github</a>
       </p>`: ''}
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
     ${lessonDetailsRequest.data.GuideType == 'markdown' ? guideContent : ''}

--- a/contexts.js
+++ b/contexts.js
@@ -1,5 +1,6 @@
 import { createContext } from 'haunted';
 
+export const CurriculumContext =createContext({});
 export const LessonContext = createContext({});
 export const LiveLessonDetailsContext = createContext({});
 export const AllLessonContext = createContext({});
@@ -11,6 +12,7 @@ export const CoursePlanStrengthsContext = createContext([]);
 export const LessonPrereqContext = createContext([]);
 export const LabTabsContext = createContext([]);
 
+customElements.define('antidote-curriculum-context-provider', CurriculumContext.Provider);
 customElements.define('antidote-lesson-context-provider', LessonContext.Provider);
 customElements.define('antidote-live-lesson-details-context-provider', LiveLessonDetailsContext.Provider);
 customElements.define('antidote-all-lesson-context-provider', AllLessonContext.Provider);


### PR DESCRIPTION
Uses the [new data in the Antidote curriculum API](https://github.com/nre-learning/antidote-core/pull/163) to present a link to the git repository where the curriculum is stored.

At this time we're linking to the root of the repository, not to the specific directory where that specific lesson can be found. This is for two reasons:
- Linking to the specific directory must also take version into account. If we link to the directory where the lesson is loaded, we must ensure the version matches what's actually loaded in Antidote at runtime, otherwise we'll send them to a 404. The downside to this, of course, is that they may be looking at an old version of the repository, and that is if everything works properly.
- It may not be useful to link directly to the lesson directory, because there is no opportunity for us to explain what the user just clicked on. My theory is that 90% of the folks that click on that won't immediately know what they're doing in terms of curriculum contributions, so it's better to link to the root of the repository where we have an opportunity in the README to point to additional resources. The other 10% know what they're doing anyways.

Closes https://github.com/nre-learning/antidote-ui-components/issues/18