### PR TITLE
Adding deprecation notice for lessonId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Antidote-Core Compatibility Updates [#15](https://github.com/nre-learning/antidote-ui-components/pull/15)
 - Standardize Lesson Guide Header [#17](https://github.com/nre-learning/antidote-ui-components/pull/17)
 - Add "Edit on Github" button [#19](https://github.com/nre-learning/antidote-ui-components/pull/19)
+- Add deprecation notice for lessonId [#20](https://github.com/nre-learning/antidote-ui-components/pull/20)
 
 ## v0.5.1 - February 17, 2020
 

--- a/components/lab-loading-modal.js
+++ b/components/lab-loading-modal.js
@@ -18,6 +18,8 @@ function LabLoadingModal() {
       console.error(lessonRequest.error);
       return html`
       <h3>${l8n('lab.loading.modal.lesson.loading.error.message', { error: lessonRequest.error })}</h3>
+      <hr />
+      <a href="/catalog/" class="btn primary">Return to Lesson Catalog</a>
     `;
     }
     else if (detailRequest.error) {

--- a/helpers/page-state.js
+++ b/helpers/page-state.js
@@ -15,15 +15,20 @@ export const [serviceHost, syringeServiceRoot, sshServiceHost] = (() => {
 })();
 
 // get params from page url query parameters
-export const [lessonSlug, lessonStage, collectionSlug] = (() => {
+export const [lessonSlug, lessonStage, collectionSlug, lessonId] = (() => {
   const url = new URL(window.location.href);
-  const id = url.searchParams.get("lessonSlug");
+  const slug = url.searchParams.get("lessonSlug");
   const stage = url.searchParams.get("lessonStage");
   const collection = url.searchParams.get("collectionSlug");
 
+  // This is a deprecated field, but we're still gathering it so we can see if someone is attempting to
+  // use it using an old URL. This will allow us to redirect them back to the catalog to find the right URL.
+  const lessonId = url.searchParams.get("lessonId");
+
   return [
-    id && id.length > 0 ? id : null,
+    slug && slug.length > 0 ? slug : null,
     stage && stage.length > 0 ? parseInt(stage) : null,
     collection && collection.length > 0 ? collection : null,
+    lessonId && lessonId.length > 0 ? parseInt(lessonId) : null,
   ]
 })();

--- a/helpers/use-fetch.js
+++ b/helpers/use-fetch.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'haunted';
-import { syringeServiceRoot} from "../helpers/page-state.js";
-
+import { syringeServiceRoot, lessonId} from "../helpers/page-state.js";
 const defaultState = {
   data: null,
   pending: false,
@@ -26,6 +25,11 @@ export default function useFetch(path, options) {
       });
 
       try {
+        if (lessonId > 0) {
+          throw new Error(`It looks like you're using an older URL with the legacy "lessonId" field.
+            This is no longer supported. Please navigate back to the lesson catalog using the button
+            below and search for your lesson.`);
+        }
         const response = await fetch(url, options);
         const data = options && options.text ? await response.text() : await response.json();
         // fetch() doesn't throw exceptions for HTTP error codes so we need to do this ourselves.
@@ -109,6 +113,11 @@ export function requestLiveLesson(path, options) {
       });
 
       try {
+        if (lessonId > 0) {
+          throw new Error(`It looks like you're using an older URL with the legacy "lessonId" field.
+            This is no longer supported. Please navigate back to the lesson catalog using the button
+            below and search for your lesson.`);
+        }
         var sessionId = await getSessionId(false);
         // Inject sessionId to body and convert to string
         options.body["sessionId"] = sessionId;


### PR DESCRIPTION
One of the biggest changes in 0.6.0 is the use of slugs to uniquely identify lessons instead of a numeric ID. Unfortunately this means that any links out there that use the old lessonId format will encounter an unhelpful "lesson not found" error, since they will have not provided the required slug.

This change detects the use of `lessonId` as a URL parameter, and when provided, gives, a slightly more helpful message, as well as a button they can click to go back to the lesson catalog, to search for their lesson and find the correct link.