### PR TITLE
Gracefully handle JSON parsing of response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add deprecation notice for lessonId [#20](https://github.com/nre-learning/antidote-ui-components/pull/20)
 - Fix diagram/video buttons/modal, and add ability to override with StageVideo [#21](https://github.com/nre-learning/antidote-ui-components/pull/21)
 - Only return labguide details if all requests succeeded [#22](https://github.com/nre-learning/antidote-ui-components/pull/22)
+- Gracefully handle JSON parsing of response body [#23](https://github.com/nre-learning/antidote-ui-components/pull/23)
 
 ## v0.5.1 - February 17, 2020
 

--- a/helpers/use-polling-request.js
+++ b/helpers/use-polling-request.js
@@ -62,7 +62,18 @@ export default function usePollingRequest({
 
         try {
           const response = await fetch(`${progressRequestURL}`);
-          const data = await response.json();
+
+          // Gracefully handle JSON parsing. This gives us a chance to output the response text if
+          // not proper JSON.
+          const respText = await response.text();
+          var data = ""
+          try {
+              data = JSON.parse(respText);
+          } catch(e) {
+              console.log(respText)
+              throw new Error(respText);
+          }
+
           // fetch() doesn't throw exceptions for HTTP error codes so we need to do this ourselves.
           if (response.status >= 400) {
               throw new Error(typeof data == "object" && data.error ? data.error : data);


### PR DESCRIPTION
[In a previous discussion](https://github.com/nre-learning/antidote-ui-components/pull/11#discussion_r371404925), we were discussing the need to move the status check in front of the call to `response.json()` so we could only try to parse the JSON in non-error cases. However, even in error scenarios, we should still attempt to parse the JSON because there might be valuable information there that we can display to the user to help explain a problem.

However, it's true that if the response is malformed JSON, then we will provide a totally **unhelpful** error message to the user in the form of an arbitrary JSON parsing error. So we do need to change this.

This PR effectively removes all calls to `response.json()` and instead always retrieves the response via `response.text()` which does not include any built-in JSON parsing. Once that is retrieved, we can then optionally perform `JSON.parse()` on the text if we are expecting that it is JSON. This separate activity has its own exception handling, so that if a JSON parsing error is encountered, we can catch it, and display the raw text to the user instead.