### PR TITLE
Fix path for HTTP presentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Gracefully handle JSON parsing of response body [#23](https://github.com/nre-learning/antidote-ui-components/pull/23)
 - Finish removing all remaining Syringe references [#24](https://github.com/nre-learning/antidote-ui-components/pull/24)
 - Fix last stage progression button bug, add stage index safety checks [#25](https://github.com/nre-learning/antidote-ui-components/pull/25)
+- Fix path for HTTP presentations [#26](https://github.com/nre-learning/antidote-ui-components/pull/26)
 
 ## v0.5.1 - February 17, 2020
 

--- a/components/lab-context.js
+++ b/components/lab-context.js
@@ -13,12 +13,13 @@ function derivePresentationsFromLessonDetails(detailsRequest) {
   return Object.values(endpoints).reduce((acc, ep) => {
     if (ep.LivePresentations) {
       ep.LivePresentations.forEach((pres) => {
-        const name = ep.LivePresentations.length > 1
+        const combinedname = ep.LivePresentations.length > 1
             ? `${ep.Name}-${pres.Name}`
             : `${ep.Name}`;
 
         acc.push({
-          name,
+          name: pres.Name,
+          combinedname: combinedname,
           endpoint: ep.Name,
           type: pres.Type,
           host: ep.Host,
@@ -51,8 +52,8 @@ customElements.define('antidote-lab-context', component(function AntidoteLabCont
   const isMobileSizedWindow = window.innerWidth < tabletBreakpoint;
   const presentations = derivePresentationsFromLessonDetails(liveLessonDetailRequest);
   const presentationTabs = presentations ? presentations.map((p, i) => ({
-    id: p.name.toLowerCase(),
-    label: p.name,
+    id: p.combinedname.toLowerCase(),
+    label: p.combinedname,
     pres: p,
     selected: isMobileSizedWindow ? false : i === 0
   })) : [];

--- a/components/lab-tabs.js
+++ b/components/lab-tabs.js
@@ -42,7 +42,7 @@ function getTabMarkup(tab) {
           <div id=${tab.id}
                tab="web" 
                ?selected=${tab.selected}>
-            <iframe src="${window.location.protocol}//${lessonDetailsRequest.data.AntidoteID}-${lessonDetailsRequest.data.ID}-${tab.id}.heps.${window.location.host}/">
+            <iframe src="${window.location.protocol}//${lessonDetailsRequest.data.AntidoteID}-${lessonDetailsRequest.data.ID}-${tab.pres.endpoint}-${tab.pres.name}.heps.${window.location.host}/">
             </iframe>
           </div>
         `;


### PR DESCRIPTION
iframe destinations for HTTP presentations are currently built using the tab ID, which works as long as the endpoint for the presentation ALSO has another presentation, forcing the tab ID to contain both the endpoint and presentation names (this is the way acore builds the ingress). However, if the only presentation for the endpoint is `http`, the tab leaves off the presentation name for simplicity. Since the iframe uses the tab ID to know where to point, this results in the wrong destination.

This PR fixes this by making sure the iframe is always using both the endpoint and presentation names consistently.