### PR TITLE
Explicitly set path for session cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Explicitly set path for session cookie [#31](https://github.com/nre-learning/antidote-ui-components/pull/31)
 
 ## v0.6.0 - April 18, 2020
 


### PR DESCRIPTION
In versions prior to 0.6.0, we were running the session generation client-side. This meant that the first page to load our code would generate a session ID and store it as a cookie. The path for this cookie was not specified, which meant that it used whatever page it was on at the time, which was almost always going to be `/`.

In 0.6.0, we moved this session generation server-side, and ran this function as part of the function to request a livelesson, which only happens if users navigate to `/labs`. In the event that the existing session stored in a cookie is deemed invalid by the server, the client-side app attempts to request a new session ID, and delete the old cookie. However, since we're not explicitly storing path, any users that had the old cookie will be unable to delete it, since the attempted new path is different from the old one. This results in users not being able to successfully use the new session ID, and the second request for a livelesson will fail, which does bubble back to the user.

This PR fixes this by explicitly providing the path parameter to all cookie deletion attempts. It first attempts to delete based on known old paths, but also creates/deletes all cookies via a parameterized path variable declared in the function. This will get us some additional predictability in case (though unlikely) this path were to change in the future.