### PR TITLE
Add collection button to lesson guide when relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Explicitly set path for session cookie [#31](https://github.com/nre-learning/antidote-ui-components/pull/31)
+- Add collection button to lesson guide when relevant [#32](https://github.com/nre-learning/antidote-ui-components/pull/32)
 
 ## v0.6.0 - April 18, 2020
 

--- a/components/lab-guide.js
+++ b/components/lab-guide.js
@@ -106,7 +106,8 @@ function LabGuide() {
       ${lessonRequest.data.Authors && lessonRequest.data.Authors.length > 0 ? html`<p style="margin-top: 0px;">
         ${lessonRequest.data.Authors.length > 1 ? l8n('lab.author.plural.label') : l8n('lab.author.singular.label')}: ${lessonRequest.data.Authors.map((author, i) => html`<a target="_blank" href="${author.Link}">${author.Name}</a>${(i>=lessonRequest.data.Authors.length-1) ? '' : ', '}`)}
       </p>`: ''}
-      <a id="github" target="_blank" class="btn primary github" href="${curriculumRequest.data.GitRoot}">Edit Lesson on Github</a>
+      ${lessonRequest.data.Collection ? html`<a id="collection" class="btn guidetool" href="/collections/view.html?collectionSlug=${lessonRequest.data.Collection}">View Collection</a>`: ''}
+      <a id="github" class="btn guidetool" href="${curriculumRequest.data.GitRoot}">Edit Lesson on Github</a>
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
     ${lessonDetailsRequest.data.GuideType == 'markdown' ? guideContent : ''}
     </div>


### PR DESCRIPTION
Pages for collections have links to the various lessons that reference them, but the reverse has not been true. This PR adds a button to the existing space where the "Edit on Github" button already exists that allows users to not only see that a lesson is part of a collection, but also to navigate straight to it. The button only shows for lessons that are in a collection.

I decided for the time being to use the static text "View Collection", instead of referencing the collection by name. This was done primarily for space considerations (in case the collection name was large) but also because doing so would require an additional API call on this page to get the collection name (we only by default get the collection slug from the livelesson details call, and this is all we need to minimally construct a link href).

Closes #30 