### PR TITLE
Use path provided by livelesson API for HEP path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add collection button to lesson guide when relevant [#32](https://github.com/nre-learning/antidote-ui-components/pull/32)
 - Add message to refresh page when terminal disconnects [#34](https://github.com/nre-learning/antidote-ui-components/pull/34)
 - Add helper tip to terminal that shows copy shortcut [#35](https://github.com/nre-learning/antidote-ui-components/pull/35)
+- Use path provided by livelesson API for HEP path [#36](https://github.com/nre-learning/antidote-ui-components/pull/36)
 
 ## v0.6.0 - April 18, 2020
 

--- a/components/lab-context.js
+++ b/components/lab-context.js
@@ -24,6 +24,7 @@ function derivePresentationsFromLessonDetails(detailsRequest) {
           type: pres.Type,
           host: ep.Host,
           port: pres.Port,
+          hepDomain: pres.HepDomain,
           user: ep.SSHUser,
           pass: ep.SSHPassword,
         });

--- a/components/lab-tabs.js
+++ b/components/lab-tabs.js
@@ -14,7 +14,6 @@ import getComponentStyleSheetURL from '../helpers/stylesheet';
 
 function getTabMarkup(tab) {
 
-  const lessonDetailsRequest = useContext(LiveLessonDetailsContext);
   if (tab.id === 'mobile-guide') {
     return html`
       <div id=${tab.id}
@@ -42,7 +41,7 @@ function getTabMarkup(tab) {
           <div id=${tab.id}
                tab="web" 
                ?selected=${tab.selected}>
-            <iframe src="${window.location.protocol}//${lessonDetailsRequest.data.AntidoteID}-${lessonDetailsRequest.data.ID}-${tab.pres.endpoint}-${tab.pres.name}.heps.${window.location.host}/">
+            <iframe src="${window.location.protocol}//${tab.pres.hepDomain}/">
             </iframe>
           </div>
         `;


### PR DESCRIPTION
In https://github.com/nre-learning/antidote-core/pull/176, we're now providing the HEP domain for an HTTP presentation via the LiveLesson API. This PR takes advantage of this so that we don't have to keep coordinating between these two projects wrt the way we calculate this domain - we just use what the API tells us to.