### PR TITLE
Html5 video player

### DIFF
--- a/components/lab-guidance-buttons.js
+++ b/components/lab-guidance-buttons.js
@@ -33,35 +33,31 @@ function LabGuidanceButtons() {
 
   return html`
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
-    
+
     <div id="leftButtons">${leftButtons}</div>
-    <div id="rightButtons">${rightButtons}</div>      
-      
+    <div id="rightButtons">${rightButtons}</div>
+
     <antidote-modal show=${modalContentType !== null}>
       ${modalContentType === 'diagram' ? html`
         <h1>${l8n('lab.guidance.modal.diagram.title')}</h1>
         <img src=${lessonRequest.data.Diagram} alt="${l8n('lab.guidance.modal.diagram.title')}"/>
       ` : ''}
-      
+
       ${modalContentType === 'video' ? html`
         <h1>${l8n('lab.guidance.modal.video.title')}</h1>
-        <div class="video-wrapper">
-          <iframe src=${lessonRequest.data.Video} frameborder="0" class="video-embed"></iframe>
-        </div>
+        <video-player source-url=${lessonRequest.data.Video}></video-player>
       ` : ''}
 
       ${modalContentType === 'stagevideo' ? html`
         <h1>${l8n('lab.guidance.modal.video.title')}</h1>
-        <div class="video-wrapper">
-          <iframe src=${lessonRequest.data.Stages[lessonStage].StageVideo} frameborder="0" class="video-embed"></iframe>
-        </div>
+        <video-player source-url=${lessonRequest.data.Stages[lessonStage].StageVideo}></video-player>
       ` : ''}
 
       ${modalContentType === 'objective' ? html`
         <h1>${l8n('lab.guidance.modal.objective.title')}</h1>
         <p>${lessonRequest.data.Stages[lessonStage].VerifyObjective}</p>
       ` : ''}
-      
+
       <button id="exit" class="btn primary" @click=${() => setModalContentType(null)}>
         ${l8n('lab.guidance.modal.close.button.label')}
       </button>

--- a/components/video-player.js
+++ b/components/video-player.js
@@ -7,21 +7,21 @@ import {
 
 import getComponentStyleSheetURL from '../helpers/stylesheet';
 
-export function getPlayerType (url) {
-  if (!url) {
+export function getPlayerType (sourceUrl) {
+  if (!sourceUrl) {
     console.error('No video url set in lesson')
     return
   }
 
-  const isYoutubeVideo = url.indexOf('youtube.com') !== -1
-    || url.indexOf('youtu.be') !== -1
+  const isYouTubeVideo = sourceUrl.indexOf('youtube.com') !== -1
+    || sourceUrl.indexOf('youtu.be') !== -1
 
-  return isYoutubeVideo ? 'youtube' : 'native'
+  return isYouTubeVideo ? 'youtube' : 'native'
 }
 
-export function getVideoType (url) {
+export function getVideoType (sourceUrl) {
   const regex = /\.\w{3,4}($|\?)/
-  const match = url && url.match(regex)
+  const match = sourceUrl && sourceUrl.match(regex)
   const videoExtension = match && match[0]
   const videoType = (typeof videoExtension === 'string')
     ? videoExtension.replace('.', '')
@@ -30,17 +30,15 @@ export function getVideoType (url) {
   return videoType
 }
 
-export function getVideoPlayer({ url, videoType, playerType }) {
-  // validate url first as good url, with supported extension for file,
-  // embed in url for youtube sources?
-  playerType = playerType || getPlayerType(url)
-  videoType = videoType || getVideoType(url)
+export function getVideoPlayer({ sourceUrl, videoType, playerType }) {
+  playerType = playerType || getPlayerType(sourceUrl)
+  videoType = videoType || getVideoType(sourceUrl)
 
   if (playerType === 'youtube') {
     return html`
       <div class="video-wrapper">
         <iframe
-          src=${url}
+          src=${sourceUrl}
           frameborder="0"
           class="video-embed">
         </iframe>
@@ -50,7 +48,7 @@ export function getVideoPlayer({ url, videoType, playerType }) {
     return html`
       <div class="native-video-wrapper">
         <video class="native-video-embed" controls>
-          <source src=${url} type="video/${getVideoType(url)}">
+          <source src=${sourceUrl} type="video/${getVideoType(sourceUrl)}">
         </video>
       </div>
     `
@@ -58,31 +56,14 @@ export function getVideoPlayer({ url, videoType, playerType }) {
 }
 
 function VideoPlayer({ sourceUrl }) {
-  const [url, setUrl] = useState('')
-  useEffect(() => {
-    if (typeof sourceUrl === 'string') {
-      setUrl(sourceUrl)
-    }
-  }, [sourceUrl]);
-
   return html`
     <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
-    ${url
+    ${sourceUrl && sourceUrl.length
     ?
       html`
-        ${getVideoPlayer({ url })}
+        ${getVideoPlayer({ sourceUrl })}
       `
-    :
-    html`
-        <div class="no-video-container">
-          <div>URL is Empty</div>
-            <video id="video" width="560" height="315">
-            </video>
-          <div class="overlay-desc">
-            <h1>No Video Selected</h1>
-          </div>
-        </div>
-      `
+    : html``
     }
   `;
 }

--- a/components/video-player.js
+++ b/components/video-player.js
@@ -1,0 +1,94 @@
+import { html } from 'lit-html';
+import {
+  component,
+  useState,
+  useEffect
+} from "haunted";
+
+import getComponentStyleSheetURL from '../helpers/stylesheet';
+
+export function getPlayerType (url) {
+  if (!url) {
+    console.error('No video url set in lesson')
+    return
+  }
+
+  const isYoutubeVideo = url.indexOf('youtube.com') !== -1
+    || url.indexOf('youtu.be') !== -1
+
+  return isYoutubeVideo ? 'youtube' : 'native'
+}
+
+export function getVideoType (url) {
+  const regex = /\.\w{3,4}($|\?)/
+  const match = url && url.match(regex)
+  const videoExtension = match && match[0]
+  const videoType = (typeof videoExtension === 'string')
+    ? videoExtension.replace('.', '')
+    : ''
+
+  return videoType
+}
+
+export function getVideoPlayer({ url, videoType, playerType }) {
+  // validate url first as good url, with supported extension for file,
+  // embed in url for youtube sources?
+  playerType = playerType || getPlayerType(url)
+  videoType = videoType || getVideoType(url)
+
+  if (playerType === 'youtube') {
+    return html`
+      <div class="video-wrapper">
+        <iframe
+          src=${url}
+          frameborder="0"
+          class="video-embed">
+        </iframe>
+      </div>
+    `
+  } else {
+    return html`
+      <div class="native-video-wrapper">
+        <video class="native-video-embed" controls>
+          <source src=${url} type="video/${getVideoType(url)}">
+        </video>
+      </div>
+    `
+  }
+}
+
+function VideoPlayer({ sourceUrl }) {
+  const [url, setUrl] = useState('')
+  useEffect(() => {
+    if (typeof sourceUrl === 'string') {
+      setUrl(sourceUrl)
+    }
+  }, [sourceUrl]);
+
+  return html`
+    <link rel="stylesheet" href=${getComponentStyleSheetURL(this)} />
+    ${url
+    ?
+      html`
+        ${getVideoPlayer({ url })}
+      `
+    :
+    html`
+        <div class="no-video-container">
+          <div>URL is Empty</div>
+            <video id="video" width="560" height="315">
+            </video>
+          <div class="overlay-desc">
+            <h1>No Video Selected</h1>
+          </div>
+        </div>
+      `
+    }
+  `;
+}
+
+VideoPlayer.observedAttributes = ['source-url'];
+
+customElements.define("video-player", component(VideoPlayer));
+
+export default VideoPlayer;

--- a/index.js
+++ b/index.js
@@ -28,4 +28,4 @@ export * from './components/course-plan-name-field.js';
 export * from './components/ptr-banner.js';
 export * from './components/promoted-lessons.js';
 export * from './components/progress-links';
-export * from './components/video-player';
+export * from './components/video-player.js';

--- a/index.js
+++ b/index.js
@@ -28,3 +28,4 @@ export * from './components/course-plan-name-field.js';
 export * from './components/ptr-banner.js';
 export * from './components/promoted-lessons.js';
 export * from './components/progress-links';
+export * from './components/video-player';


### PR DESCRIPTION
Adds video-player component that allows for html5 native video sources, taking a `source-url` custom attribute. Currently only assumes youtube and native sources, but could be expanded for Vimeo and other embedded online video sources.

`<video-player source-url="http://localhost/oceans.mp4"></video-player>`

TODO:
- updating html5 video styles in `nre-styles` -- https://github.com/nre-learning/nre-styles/pull/12
- working on adding at least functional tests for this component
- possibly add url validation with feedback for authors/users?